### PR TITLE
Eliza admin invoices

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -1,0 +1,5 @@
+class Admin::InvoicesController < ApplicationController
+  def index
+    @invoices = Invoice.all
+  end
+end

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -5,7 +5,6 @@ class Admin::InvoicesController < ApplicationController
 
   def show
     @invoice = Invoice.find(params[:id])
-    @invoice_items = InvoiceItem.find_items(@invoice)
   end
 
   def update

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -4,12 +4,12 @@ class Admin::InvoicesController < ApplicationController
   end
 
   def show
-    @invoice = Invoice.find(params[:invoice_id])
+    @invoice = Invoice.find(params[:id])
     @invoice_items = InvoiceItem.find_items(@invoice)
   end
 
   def update
-    invoice = Invoice.find(params[:invoice_id])
+    invoice = Invoice.find(params[:id])
     invoice.update!(status: params[:status])
 
     redirect_to "/admin/invoices/#{invoice.id}"

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -5,6 +5,7 @@ class Admin::InvoicesController < ApplicationController
 
   def show
     @invoice = Invoice.find(params[:invoice_id])
+    @invoice_items = InvoiceItem.find_items(@invoice)
   end
 
   def update

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -6,4 +6,11 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:invoice_id])
   end
+
+  def update
+    invoice = Invoice.find(params[:invoice_id])
+    invoice.update!(status: params[:status])
+
+    redirect_to "/admin/invoices/#{invoice.id}"
+  end
 end

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -2,4 +2,8 @@ class Admin::InvoicesController < ApplicationController
   def index
     @invoices = Invoice.all
   end
+
+  def show
+    @invoice = Invoice.find(params[:invoice_id])
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,4 +7,8 @@ class Invoice < ApplicationRecord
   has_many :items, through: :invoice_items
 
   validates :status, presence: true #inclusion:{in: ["cancelled", "completed", "in progress"]}
+
+  def total_revenue
+    Invoice.joins(:invoice_items).where(id: self.id).sum("invoice_items.quantity * invoice_items.unit_price")
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -9,6 +9,6 @@ class Invoice < ApplicationRecord
   validates :status, presence: true #inclusion:{in: ["cancelled", "completed", "in progress"]}
 
   def total_revenue
-    Invoice.joins(:invoice_items).where(id: self.id).sum("invoice_items.quantity * invoice_items.unit_price")
+    invoice_items.sum('quantity * unit_price')
   end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -8,8 +8,4 @@ class InvoiceItem < ApplicationRecord
   validates :unit_price, presence: true
   validates :status, presence: true
 
-  def self.find_items(current_invoice)
-    InvoiceItem.joins(:item).select("invoice_items.quantity, invoice_items.status, invoice_items.unit_price, items.name").where("invoice_items.invoice_id = ?", current_invoice.id)
-  end
-
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -7,4 +7,9 @@ class InvoiceItem < ApplicationRecord
   validates :quantity, presence: true
   validates :unit_price, presence: true
   validates :status, presence: true
+
+  def self.find_items(current_invoice)
+    InvoiceItem.joins(:item).select("invoice_items.quantity, invoice_items.status, invoice_items.unit_price, items.name").where("invoice_items.invoice_id = ?", current_invoice.id)
+  end
+
 end

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -1,0 +1,5 @@
+<h1>Admin Invoices</h1>
+
+<% @invoices.each do |invoice| %>
+  <p><%= invoice.id %></p>
+<% end %>

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -1,5 +1,5 @@
-<h1>Admin Invoices</h1>
+<h1>Invoices</h1>
 
 <% @invoices.each do |invoice| %>
-  <p><%= invoice.id %></p>
+  <p><%= link_to "Invoice ##{invoice.id}", "/admin/invoices/#{invoice.id}" %></p>
 <% end %>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -9,3 +9,9 @@
 <p>Total Revenue: <%= number_to_currency((@invoice.total_revenue)/100.0) %></p>
 <p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
 
+<h2>Items on this Invoice:</h2>
+<% @invoice_items.each do |item| %>
+  <p>Item Name: <%= item.name %> Quantity: <%= item.quantity %> Unit Price: <%= number_to_currency((item.unit_price)/100.0) %> Status: <%= item.status %></p>
+<% end %>
+
+

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,11 +1,11 @@
-<h1>Invoice <%= @invoice.id %></h1>
+<h1>Invoice #<%= @invoice.id %></h1>
 
 <%= form_with url: "/admin/invoices/#{@invoice.id}", method: :patch, data: { turbo: false } do |form| %>
   <%= form.label :status, "Status:" %>
   <%= form.select :status, ["cancelled", "completed", "in progress"], selected: @invoice.status %>
   <%= form.submit "Update Invoice" %>
 <% end %>
-<p>Created: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
+<p>Created on: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
 <p>Total Revenue: <%= number_to_currency((@invoice.total_revenue)/100.0) %></p>
 <p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
 

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,0 +1,6 @@
+<h1>Invoice <%= @invoice.id %></h1>
+
+<p>Status: <%= @invoice.status %></p>
+<p>Created: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
+<p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
+

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -3,7 +3,7 @@
 <%= form_with url: "/admin/invoices/#{@invoice.id}", method: :patch, data: { turbo: false } do |form| %>
   <%= form.label :status, "Status:" %>
   <%= form.select :status, ["cancelled", "completed", "in progress"], selected: @invoice.status %>
-  <%= form.submit "Update Invoice" %>
+  <%= form.submit "Update Invoice Status" %>
 <% end %>
 <p>Created on: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
 <p>Total Revenue: <%= number_to_currency((@invoice.total_revenue)/100.0) %></p>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,6 +1,10 @@
 <h1>Invoice <%= @invoice.id %></h1>
 
-<p>Status: <%= @invoice.status %></p>
+<%= form_with url: "/admin/invoices/#{@invoice.id}", method: :patch, data: { turbo: false } do |form| %>
+  <%= form.label :status, "Status:" %>
+  <%= form.select :status, ["cancelled", "completed", "in progress"], selected: @invoice.status %>
+  <%= form.submit "Update Invoice" %>
+<% end %>
 <p>Created: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
 <p>Total Revenue: <%= number_to_currency((@invoice.total_revenue)/100.0) %></p>
 <p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -10,8 +10,8 @@
 <p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
 
 <h2>Items on this Invoice:</h2>
-<% @invoice_items.each do |item| %>
-  <p>Item Name: <%= item.name %> Quantity: <%= item.quantity %> Unit Price: <%= number_to_currency((item.unit_price)/100.0) %> Status: <%= item.status %></p>
+<% @invoice.invoice_items.each do |invoice_item| %>
+  <p>Item Name: <%= invoice_item.item.name %> Quantity: <%= invoice_item.quantity %> Unit Price: <%= number_to_currency((invoice_item.unit_price)/100.0) %> Status: <%= invoice_item.status %></p>
 <% end %>
 
 

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -2,5 +2,6 @@
 
 <p>Status: <%= @invoice.status %></p>
 <p>Created: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
+<p>Total Revenue: <%= number_to_currency((@invoice.total_revenue)/100.0) %></p>
 <p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,6 @@ Rails.application.routes.draw do
   get "/admin/merchants/:merchant_id/edit", to: "admin/merchants#edit"
   patch "/admin/merchants/:merchant_id", to: "admin/merchants#update"
   post "/admin/merchants", to: "admin/merchants#create"
+
+  get "/admin/invoices", to: "admin/invoices#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,4 +22,5 @@ Rails.application.routes.draw do
 
   get "/admin/invoices", to: "admin/invoices#index"
   get "/admin/invoices/:invoice_id", to: "admin/invoices#show"
+  patch "/admin/invoices/:invoice_id", to: "admin/invoices#update"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,9 @@ Rails.application.routes.draw do
   patch "/admin/merchants/:merchant_id", to: "admin/merchants#update"
   post "/admin/merchants", to: "admin/merchants#create"
 
-  get "/admin/invoices", to: "admin/invoices#index"
-  get "/admin/invoices/:invoice_id", to: "admin/invoices#show"
-  patch "/admin/invoices/:invoice_id", to: "admin/invoices#update"
+  namespace :admin do
+    resources :invoices, only: [:index, :show, :update]
+  end
 
   resources :admin, only: [:index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,5 @@ Rails.application.routes.draw do
   post "/admin/merchants", to: "admin/merchants#create"
 
   get "/admin/invoices", to: "admin/invoices#index"
+  get "/admin/invoices/:invoice_id", to: "admin/invoices#show"
 end

--- a/spec/features/admin/invoices/index_spec.rb
+++ b/spec/features/admin/invoices/index_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "Admin Invoices Index Page", type: :feature do
+  describe "when I visit '/admin/invoices" do
+    it "I see a list of all invoice ids in the system and each id links to the admin invoice show page" do
+      customer_1 = create(:customer)
+
+      invoices_for_customer_1 = create_list(:invoice, 5, customer: customer_1)
+
+      visit admin_invoices_path
+
+      expect(page).to have_content("Admin Invoices")
+
+      invoices_for_customer_1.each do |invoice|
+        expect(page).to have_link "#{invoice.id}", href: "/admin/invoices/#{invoice.id}"
+      end
+    end
+  end
+end

--- a/spec/features/admin/invoices/index_spec.rb
+++ b/spec/features/admin/invoices/index_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe "Admin Invoices Index Page", type: :feature do
 
       visit admin_invoices_path
 
-      expect(page).to have_content("Admin Invoices")
+      expect(page).to have_content("Invoices")
 
       invoices_for_customer_1.each do |invoice|
+        expect(page).to have_content("Invoice ##{invoice.id}")
         expect(page).to have_link "#{invoice.id}", href: "/admin/invoices/#{invoice.id}"
       end
     end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -1,58 +1,43 @@
 require "rails_helper"
 
 RSpec.describe "Admin Invoice Show Page", type: :feature do
+  before(:each) do
+    @customer_1 = create(:customer)
+
+    @invoice_1 = create(:invoice, created_at: "2012-03-25 09:54:09 UTC", customer: @customer_1)
+
+    @merchant_1 = create(:merchant)
+
+    @item_1 = create(:item, merchant: @merchant_1)
+    @item_2 = create(:item, merchant: @merchant_1)
+    @item_3 = create(:item, merchant: @merchant_1)
+
+    @invoice_item_1 = create(:invoice_item, quantity: 5, unit_price: 24642, invoice: @invoice_1, item: @item_1)
+    @invoice_item_2 = create(:invoice_item, quantity: 8, unit_price: 12463, invoice: @invoice_1, item: @item_2)
+    @invoice_item_3 = create(:invoice_item, quantity: 2, unit_price: 23567, invoice: @invoice_1, item: @item_3)
+  end
   describe "when I visit '/admin/invoices/:invoice_id'" do
     it "I the invoice ic, invoice status, invoice created_at in correct format, and customer first and last name" do
-      customer_1 = create(:customer)
+      visit "/admin/invoices/#{@invoice_1.id}"
 
-      invoice_1 = create(:invoice, created_at: "2012-03-25 09:54:09 UTC", customer: customer_1)
-
-      visit "/admin/invoices/#{invoice_1.id}"
-
-      expect(page).to have_content("Invoice #{invoice_1.id}")
-      expect(page).to have_select("Status:", selected: "#{invoice_1.status}")
+      expect(page).to have_content("Invoice #{@invoice_1.id}")
+      expect(page).to have_select("Status:", selected: "#{@invoice_1.status}")
       expect(page).to have_content("Created: Sunday, March 25, 2012")
-      expect(page).to have_content("Customer: #{customer_1.first_name} #{customer_1.last_name}")
+      expect(page).to have_content("Customer: #{@customer_1.first_name} #{@customer_1.last_name}")
     end
 
     it "I see all of the invoice's items, including the item name, the quantity ordered, the price it sold at, and the invoice item status" do
-      customer_1 = create(:customer)
-
-      invoice_1 = create(:invoice, customer: customer_1)
-
-      merchant_1 = create(:merchant)
-
-      item_1 = create(:item, merchant: merchant_1)
-      item_2 = create(:item, merchant: merchant_1)
-      item_3 = create(:item, merchant: merchant_1)
-
-      invoice_item_1 = create(:invoice_item, unit_price: 93675, invoice: invoice_1, item: item_1)
-      invoice_item_2 = create(:invoice_item, unit_price: 23756, invoice: invoice_1, item: item_2)
-      invoice_item_3 = create(:invoice_item, unit_price: 79265, invoice: invoice_1, item: item_3)
-
-      visit "/admin/invoices/#{invoice_1.id}"
+      visit "/admin/invoices/#{@invoice_1.id}"
 
       expect(page).to have_content("Items on this Invoice:")
 
-      expect(page).to have_content("Item Name: #{item_1.name} Quantity: #{invoice_item_1.quantity} Unit Price: $936.75 Status: #{invoice_item_1.status}")
-      expect(page).to have_content("Item Name: #{item_2.name} Quantity: #{invoice_item_2.quantity} Unit Price: $237.56 Status: #{invoice_item_2.status}")
-      expect(page).to have_content("Item Name: #{item_3.name} Quantity: #{invoice_item_3.quantity} Unit Price: $792.65 Status: #{invoice_item_3.status}")
+      expect(page).to have_content("Item Name: #{@item_1.name} Quantity: #{@invoice_item_1.quantity} Unit Price: $246.42 Status: #{@invoice_item_1.status}")
+      expect(page).to have_content("Item Name: #{@item_2.name} Quantity: #{@invoice_item_2.quantity} Unit Price: $124.63 Status: #{@invoice_item_2.status}")
+      expect(page).to have_content("Item Name: #{@item_3.name} Quantity: #{@invoice_item_3.quantity} Unit Price: $235.67 Status: #{@invoice_item_3.status}")
     end
 
     it "I see the total revenue that will be generated from this invoice" do
-      customer_1 = create(:customer)
-
-      invoice_1 = create(:invoice, customer: customer_1)
-
-      merchant_1 = create(:merchant)
-
-      item_1 = create(:item, merchant: merchant_1)
-
-      invoice_item_1 = create(:invoice_item, quantity: 5, unit_price: 24642, invoice: invoice_1, item: item_1)
-      invoice_item_2 = create(:invoice_item, quantity: 8, unit_price: 12463, invoice: invoice_1, item: item_1)
-      invoice_item_2 = create(:invoice_item, quantity: 2, unit_price: 23567, invoice: invoice_1, item: item_1)
-
-      visit "/admin/invoices/#{invoice_1.id}"
+      visit "/admin/invoices/#{@invoice_1.id}"
 
       expect(page).to have_content("Total Revenue: $2,700.48")
     end
@@ -61,11 +46,7 @@ RSpec.describe "Admin Invoice Show Page", type: :feature do
   describe "I see the invoice status is a select field with the current status selected" do
     describe "When I click this I can change the status for the invoice and use the button update invoice status" do
       it "when I click the button I am taken back to the show page and the status has been updated" do
-      customer_1 = create(:customer)
-
-      invoice_1 = create(:invoice, status: 2, customer: customer_1)
-
-      visit "/admin/invoices/#{invoice_1.id}"
+      visit "/admin/invoices/#{@invoice_1.id}"
 
       select "completed", from: "Status:"
 

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "Admin Invoice Show Page", type: :feature do
+  describe "when I visit '/admin/invoices/:invoice_id'" do
+    it "I the invoice ic, invoice status, invoice created_at in correct format, and customer first and last name" do
+      customer_1 = create(:customer)
+
+      invoice_1 = create(:invoice, created_at: "2012-03-25 09:54:09 UTC", customer: customer_1)
+
+      visit "/admin/invoices/#{invoice_1.id}"
+
+      expect(page).to have_content("Invoice #{invoice_1.id}")
+      expect(page).to have_content("Status: #{invoice_1.status}")
+      expect(page).to have_content("Created: Sunday, March 25, 2012")
+      expect(page).to have_content("Customer: #{customer_1.first_name} #{customer_1.last_name}")
+    end
+  end
+end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Admin Invoice Show Page", type: :feature do
 
       select "completed", from: "Status:"
 
-      click_button "Update Invoice"
+      click_button "Update Invoice Status"
 
       expect(page).to have_select("Status:", selected: "completed")
       end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe "Admin Invoice Show Page", type: :feature do
     @invoice_item_1 = create(:invoice_item, quantity: 5, unit_price: 24642, invoice: @invoice_1, item: @item_1)
     @invoice_item_2 = create(:invoice_item, quantity: 8, unit_price: 12463, invoice: @invoice_1, item: @item_2)
     @invoice_item_3 = create(:invoice_item, quantity: 2, unit_price: 23567, invoice: @invoice_1, item: @item_3)
+
+    visit admin_invoice_path(@invoice_1.id)
   end
   describe "when I visit '/admin/invoices/:invoice_id'" do
     it "I the invoice ic, invoice status, invoice created_at in correct format, and customer first and last name" do
-      visit "/admin/invoices/#{@invoice_1.id}"
-
       expect(page).to have_content("Invoice ##{@invoice_1.id}")
       expect(page).to have_select("Status:", selected: "#{@invoice_1.status}")
       expect(page).to have_content("Created on: Sunday, March 25, 2012")
@@ -27,8 +27,6 @@ RSpec.describe "Admin Invoice Show Page", type: :feature do
     end
 
     it "I see all of the invoice's items, including the item name, the quantity ordered, the price it sold at, and the invoice item status" do
-      visit "/admin/invoices/#{@invoice_1.id}"
-
       expect(page).to have_content("Items on this Invoice:")
 
       expect(page).to have_content("Item Name: #{@item_1.name} Quantity: #{@invoice_item_1.quantity} Unit Price: $246.42 Status: #{@invoice_item_1.status}")
@@ -37,8 +35,6 @@ RSpec.describe "Admin Invoice Show Page", type: :feature do
     end
 
     it "I see the total revenue that will be generated from this invoice" do
-      visit "/admin/invoices/#{@invoice_1.id}"
-
       expect(page).to have_content("Total Revenue: $2,700.48")
     end
   end
@@ -46,12 +42,11 @@ RSpec.describe "Admin Invoice Show Page", type: :feature do
   describe "I see the invoice status is a select field with the current status selected" do
     describe "When I click this I can change the status for the invoice and use the button update invoice status" do
       it "when I click the button I am taken back to the show page and the status has been updated" do
-      visit "/admin/invoices/#{@invoice_1.id}"
-
       select "completed", from: "Status:"
 
       click_button "Update Invoice Status"
 
+      expect(current_path).to eq(admin_invoice_path(@invoice_1.id))
       expect(page).to have_select("Status:", selected: "completed")
       end
     end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe "Admin Invoice Show Page", type: :feature do
     it "I the invoice ic, invoice status, invoice created_at in correct format, and customer first and last name" do
       visit "/admin/invoices/#{@invoice_1.id}"
 
-      expect(page).to have_content("Invoice #{@invoice_1.id}")
+      expect(page).to have_content("Invoice ##{@invoice_1.id}")
       expect(page).to have_select("Status:", selected: "#{@invoice_1.status}")
-      expect(page).to have_content("Created: Sunday, March 25, 2012")
+      expect(page).to have_content("Created on: Sunday, March 25, 2012")
       expect(page).to have_content("Customer: #{@customer_1.first_name} #{@customer_1.last_name}")
     end
 

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -15,6 +15,30 @@ RSpec.describe "Admin Invoice Show Page", type: :feature do
       expect(page).to have_content("Customer: #{customer_1.first_name} #{customer_1.last_name}")
     end
 
+    it "I see all of the invoice's items, including the item name, the quantity ordered, the price it sold at, and the invoice item status" do
+      customer_1 = create(:customer)
+
+      invoice_1 = create(:invoice, customer: customer_1)
+
+      merchant_1 = create(:merchant)
+
+      item_1 = create(:item, merchant: merchant_1)
+      item_2 = create(:item, merchant: merchant_1)
+      item_3 = create(:item, merchant: merchant_1)
+
+      invoice_item_1 = create(:invoice_item, unit_price: 93675, invoice: invoice_1, item: item_1)
+      invoice_item_2 = create(:invoice_item, unit_price: 23756, invoice: invoice_1, item: item_2)
+      invoice_item_3 = create(:invoice_item, unit_price: 79265, invoice: invoice_1, item: item_3)
+
+      visit "/admin/invoices/#{invoice_1.id}"
+
+      expect(page).to have_content("Items on this Invoice:")
+
+      expect(page).to have_content("Item Name: #{item_1.name} Quantity: #{invoice_item_1.quantity} Unit Price: $936.75 Status: #{invoice_item_1.status}")
+      expect(page).to have_content("Item Name: #{item_2.name} Quantity: #{invoice_item_2.quantity} Unit Price: $237.56 Status: #{invoice_item_2.status}")
+      expect(page).to have_content("Item Name: #{item_3.name} Quantity: #{invoice_item_3.quantity} Unit Price: $792.65 Status: #{invoice_item_3.status}")
+    end
+
     it "I see the total revenue that will be generated from this invoice" do
       customer_1 = create(:customer)
 

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -14,5 +14,23 @@ RSpec.describe "Admin Invoice Show Page", type: :feature do
       expect(page).to have_content("Created: Sunday, March 25, 2012")
       expect(page).to have_content("Customer: #{customer_1.first_name} #{customer_1.last_name}")
     end
+
+    it "I see the total revenue that will be generated from this invoice" do
+      customer_1 = create(:customer)
+
+      invoice_1 = create(:invoice, customer: customer_1)
+
+      merchant_1 = create(:merchant)
+
+      item_1 = create(:item, merchant: merchant_1)
+
+      invoice_item_1 = create(:invoice_item, quantity: 5, unit_price: 24642, invoice: invoice_1, item: item_1)
+      invoice_item_2 = create(:invoice_item, quantity: 8, unit_price: 12463, invoice: invoice_1, item: item_1)
+      invoice_item_2 = create(:invoice_item, quantity: 2, unit_price: 23567, invoice: invoice_1, item: item_1)
+
+      visit "/admin/invoices/#{invoice_1.id}"
+
+      expect(page).to have_content("Total Revenue: $2,700.48")
+    end
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Admin Invoice Show Page", type: :feature do
       visit "/admin/invoices/#{invoice_1.id}"
 
       expect(page).to have_content("Invoice #{invoice_1.id}")
-      expect(page).to have_content("Status: #{invoice_1.status}")
+      expect(page).to have_select("Status:", selected: "#{invoice_1.status}")
       expect(page).to have_content("Created: Sunday, March 25, 2012")
       expect(page).to have_content("Customer: #{customer_1.first_name} #{customer_1.last_name}")
     end
@@ -31,6 +31,24 @@ RSpec.describe "Admin Invoice Show Page", type: :feature do
       visit "/admin/invoices/#{invoice_1.id}"
 
       expect(page).to have_content("Total Revenue: $2,700.48")
+    end
+  end
+
+  describe "I see the invoice status is a select field with the current status selected" do
+    describe "When I click this I can change the status for the invoice and use the button update invoice status" do
+      it "when I click the button I am taken back to the show page and the status has been updated" do
+      customer_1 = create(:customer)
+
+      invoice_1 = create(:invoice, status: 2, customer: customer_1)
+
+      visit "/admin/invoices/#{invoice_1.id}"
+
+      select "completed", from: "Status:"
+
+      click_button "Update Invoice"
+
+      expect(page).to have_select("Status:", selected: "completed")
+      end
     end
   end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -15,4 +15,31 @@ RSpec.describe InvoiceItem, type: :model do
     it { should validate_presence_of :unit_price }
     it { should validate_presence_of :status }
   end
+
+  describe ".find_items" do
+    it "returns the name of an item associated with an invoice item, as well as the invoice items quantity, unit price, and status" do
+      customer_1 = create(:customer)
+
+      invoice_1 = create(:invoice, customer: customer_1)
+
+      merchant_1 = create(:merchant)
+
+      item_1 = create(:item, name: "Item 1", merchant: merchant_1)
+
+      invoice_item_1 = InvoiceItem.create!(
+        item: item_1,
+        invoice: invoice_1,
+        quantity: 2,
+        unit_price: 36742,
+        status: "shipped"
+      )
+
+      item = InvoiceItem.find_items(invoice_1)
+
+      expect(item.first.name).to eq("Item 1")
+      expect(item.first.quantity).to eq(2)
+      expect(item.first.unit_price).to eq(36742)
+      expect(item.first.status).to eq("shipped")
+    end
+  end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -15,31 +15,4 @@ RSpec.describe InvoiceItem, type: :model do
     it { should validate_presence_of :unit_price }
     it { should validate_presence_of :status }
   end
-
-  describe ".find_items" do
-    it "returns the name of an item associated with an invoice item, as well as the invoice items quantity, unit price, and status" do
-      customer_1 = create(:customer)
-
-      invoice_1 = create(:invoice, customer: customer_1)
-
-      merchant_1 = create(:merchant)
-
-      item_1 = create(:item, name: "Item 1", merchant: merchant_1)
-
-      invoice_item_1 = InvoiceItem.create!(
-        item: item_1,
-        invoice: invoice_1,
-        quantity: 2,
-        unit_price: 36742,
-        status: "shipped"
-      )
-
-      item = InvoiceItem.find_items(invoice_1)
-
-      expect(item.first.name).to eq("Item 1")
-      expect(item.first.quantity).to eq(2)
-      expect(item.first.unit_price).to eq(36742)
-      expect(item.first.status).to eq("shipped")
-    end
-  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -14,4 +14,22 @@ RSpec.describe Invoice, type: :model do
   describe "validations" do
     it { should validate_presence_of :status }
   end
+
+  describe "total_revenue" do
+    it "returns total revenue of an invoice" do
+      customer_1 = create(:customer)
+
+      invoice_1 = create(:invoice, customer: customer_1)
+
+      merchant_1 = create(:merchant)
+
+      item_1 = create(:item, merchant: merchant_1)
+
+      invoice_item_1 = create(:invoice_item, quantity: 5, unit_price: 24642, invoice: invoice_1, item: item_1)
+      invoice_item_2 = create(:invoice_item, quantity: 8, unit_price: 12463, invoice: invoice_1, item: item_1)
+      invoice_item_2 = create(:invoice_item, quantity: 2, unit_price: 23567, invoice: invoice_1, item: item_1)
+
+      expect(invoice_1.total_revenue).to eq(270048)
+    end
+  end
 end


### PR DESCRIPTION
## Description

Implemented the Admin Invoices (US 32-36) section.

US 32 includes:
- An admin invoices index page that shows the invoice ids of all invoices

US 33 includes:
- An admin invoice show page that shows:
   - invoice id
   - invoice status
   - invoice created_at date in format "Day, Month Date, Year"
   - customer of the invoice's first and last name

US 34 includes:
- A section on the invoice show page that showcases all of that invoice's items, including:
   - item name
   - quantity of item ordered
   - price the item sold for
   - invoice item status

US 35 includes:
- A line on the invoice show page that showcases that invoice's total revenue

US 36 includes:
- A select field for the invoice status and an 'Update Invoice Status' button that when clicked updates the invoice's status

## Type of change

- [ ] fix
- [x] feat
- [x] test
- [x] refactor
- [ ] docs

## Checklist

- [x] code has been self reviewed
- [x] code runs without any errors
- [x] thorough testing has been implemented if adding feature
- [x] all tests pass

### Thanks!